### PR TITLE
fix: variant price gets invalid values

### DIFF
--- a/src/util/getVariantPriceRange.js
+++ b/src/util/getVariantPriceRange.js
@@ -13,18 +13,27 @@ export default function getVariantPriceRange(variantId, variants) {
   const visibleOptions = variants.filter((option) => option.ancestors.includes(variantId) &&
     option.isVisible && !option.isDeleted);
 
-  const allOptions = variants.filter((option) => option.ancestors.includes(variantId));
+  // all options include visible and hidden options. Deleted options are not considered
+  const allOptions = variants.filter((option) => option.ancestors.includes(variantId) && !option.isDeleted);
 
-  // If the variant has options, but they are not visible return a price range of 0
+
+  // If the variant has options and the options are hidden, return a price range of 0
   if (allOptions.length && visibleOptions.length === 0) {
     return getPriceRange([0]);
   }
 
+  // If a variant has no visible options return price as it is
+  // If price is not an object, get the PriceRange object
   if (visibleOptions.length === 0) {
     const thisVariant = variants.find((option) => option._id === variantId);
-    return getPriceRange([(thisVariant && thisVariant.price) || 0]);
+    const price = (thisVariant && thisVariant.price) || 0;
+    if (typeof thisVariant.price === "object") {
+      return price;
+    }
+    return getPriceRange([price]);
   }
 
+  // If a variant has one or more visible options, calculate price range for all options
   const prices = visibleOptions.map((option) => option.price);
   return getPriceRange(prices);
 }

--- a/src/util/getVariantPriceRange.test.js
+++ b/src/util/getVariantPriceRange.test.js
@@ -1,7 +1,7 @@
 import getVariantPriceRange from "./getVariantPriceRange.js";
 
 const internalCatalogProductId = "999";
-const internalVariantIds = ["875", "874", "873"];
+const internalVariantIds = ["875", "874", "873", "885", "884"];
 
 const mockVariants = [
   {
@@ -24,6 +24,20 @@ const mockVariants = [
     isDeleted: false,
     isVisible: true,
     price: 3.99
+  },
+  {
+    _id: internalVariantIds[3],
+    ancestors: [internalCatalogProductId],
+    isDeleted: false,
+    isVisible: true,
+    price: 9.99
+  },
+  {
+    _id: internalVariantIds[4],
+    ancestors: [internalCatalogProductId, internalVariantIds[3]],
+    isDeleted: false,
+    isVisible: false,
+    price: 7.99
   }
 ];
 
@@ -68,6 +82,27 @@ test("expect variant price string if variants have same price", () => {
     range: "5.99",
     max: 5.99,
     min: 5.99
+  };
+  expect(spec).toEqual(success);
+});
+
+test("expect variant with all hidden options to return 0", () => {
+  const spec = getVariantPriceRange(internalVariantIds[3], mockVariants);
+  const success = {
+    range: "0.00",
+    max: 0,
+    min: 0
+  };
+  expect(spec).toEqual(success);
+});
+
+test("expect variant with all deleted options to return its own price", () => {
+  mockVariants[4].isDeleted = true;
+  const spec = getVariantPriceRange(internalVariantIds[3], mockVariants);
+  const success = {
+    range: "9.99",
+    max: 9.99,
+    min: 9.99
   };
   expect(spec).toEqual(success);
 });


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #13 
Impact: **major**
Type: **bugfix**

## Issue
1. When updating the price of an option (say _Opt1_) the price of its parent's sibling with no (visible or hidden) options gets updated with non numeric values. This creates an invalid price object for that variant. This invalid object chains on more invalid values at each price update of _Opt1_. This is happening because _getPriceRange()_ expects a float array as input but it gets an object.
2. Variant with archived options is being considered as variant with hidden options. This is setting the price of the variant to zero. The variant should retain its current price and should not be updated to zero.

## Solution
1. The variant with no options should retain its price object as it is. If the price is not a _priceRange_ object we generate a priceRange object from its int/float price. Object values are no more sent to _getPriceRange()_(Lines 29-33)
2. The variable _allOptions_ should not include deleted options. (line 17)

## Testing
Issue 1:
1. Create products structure with 2 variants and an option for one of the variant like in the image below. Note that Red pen should not have any deleted options.
![image](https://user-images.githubusercontent.com/75854210/106775227-890c7a80-6608-11eb-8aaf-3c6b528fe256.png)
2. Try the below query:
     `{
  product(shopId:"<shopId>" productId:"<productId>"){
    description
    title
    variants{
      _id
      title
      pricing{
        price
        minPrice
        maxPrice
        displayPrice
      }
      options{
        _id
        title
        attributeLabel
        pricing{
          price
        	minPrice
        	maxPrice
        	displayPrice
        }
      }
    }
  }
}`
3. Error: 
![image](https://user-images.githubusercontent.com/75854210/106777937-105aed80-660b-11eb-9d31-272642a62274.png)
4. Expected: The values should be queried without throwing errors.

Issue 2:
1. To the same product structure add an option to Red pen, save and then delete it.
2. Red pen will have its price reset to zero. Update the price to some valid value and save. Observe values is graphQL (same query as above)
3. Update the price of the option _Set of 5_ and then observe the price of Red pen in graphQL. It gets reset to zero.
4. Expected: The price should not get reset to zero.
