### PR TITLE
fix: product min price gets set to zero

### DIFF
--- a/src/util/getProductPriceRange.js
+++ b/src/util/getProductPriceRange.js
@@ -16,10 +16,11 @@ export default function getProductPriceRange(productId, variants) {
   // If there are no visible variants, set price range to 0
   if (visibleVariants.length === 0) return getPriceRange([0]);
 
-  const variantPrices = [];
+  let variantPrices = [];
   visibleVariants.forEach((variant) => {
     const { min, max } = getVariantPriceRange(variant._id, variants);
     variantPrices.push(min, max);
   });
+  variantPrices = variantPrices.filter((price) => price !== 0);
   return getPriceRange(variantPrices);
 }

--- a/src/util/getProductPriceRange.test.js
+++ b/src/util/getProductPriceRange.test.js
@@ -5,7 +5,7 @@ const mockGetVariantPriceRange = jest.fn().mockName("getVariantPriceRange");
 
 const internalShopId = "123";
 const internalCatalogProductId = "999";
-const internalVariantIds = ["875", "874"];
+const internalVariantIds = ["875", "874", "873", "872"];
 
 const createdAt = new Date("2018-04-16T15:34:28.043Z");
 const updatedAt = new Date("2018-04-17T15:34:28.043Z");
@@ -78,11 +78,84 @@ const mockVariants = [
     width: 2
   }
 ];
+const moreMockVariants = [
+  {
+    _id: internalVariantIds[2],
+    ancestors: [internalCatalogProductId],
+    barcode: "barcode",
+    createdAt,
+    height: 0,
+    index: 0,
+    isDeleted: false,
+    isVisible: true,
+    length: 0,
+    metafields: [
+      {
+        value: "value",
+        namespace: "namespace",
+        description: "description",
+        valueType: "valueType",
+        scope: "scope",
+        key: "key"
+      }
+    ],
+    minOrderQuantity: 0,
+    optionTitle: "Untitled Option",
+    originCountry: "US",
+    price: 3.99,
+    shopId: internalShopId,
+    sku: "sku",
+    taxCode: "0000",
+    taxDescription: "taxDescription",
+    title: "Large Concrete Pizza",
+    updatedAt,
+    variantId: internalVariantIds[2],
+    weight: 0,
+    width: 0
+  },
+  {
+    _id: internalVariantIds[3],
+    ancestors: [internalCatalogProductId, internalVariantIds[2]],
+    barcode: "barcode",
+    height: 2,
+    index: 0,
+    isDeleted: false,
+    isVisible: false,
+    length: 2,
+    metafields: [
+      {
+        value: "value",
+        namespace: "namespace",
+        description: "description",
+        valueType: "valueType",
+        scope: "scope",
+        key: "key"
+      }
+    ],
+    minOrderQuantity: 0,
+    optionTitle: "Square cut",
+    originCountry: "US",
+    price: 0,
+    shopId: internalShopId,
+    sku: "sku",
+    taxCode: "0000",
+    taxDescription: "taxDescription",
+    title: "Square cut",
+    variantId: internalVariantIds[1],
+    weight: 2,
+    width: 2
+  }
+];
 
 const mockPriceRange = {
   range: "2.99 - 5.99",
   max: 5.99,
   min: 2.99
+};
+const mockPriceRange2 = {
+  range: "0.00 - 0.00",
+  max: 0.00,
+  min: 0.00
 };
 
 beforeAll(() => {
@@ -110,3 +183,15 @@ test("expect to throw an error if no product is found", () => {
     expect(error).toEqual("Product not found");
   }
 });
+
+// expect valid price range with hidden variant. The hidden variant's price should not affect product price range
+test("expect hidden variant's zero price to not affect product price range", () => {
+  mockVariants.push(...moreMockVariants);
+  mockGetVariantPriceRange
+    .mockReturnValueOnce(mockPriceRange)
+    .mockReturnValueOnce(mockPriceRange2);
+  const spec = getProductPriceRange("999", mockVariants);
+  expect(spec).toEqual(mockPriceRange);
+});
+
+


### PR DESCRIPTION
Signed-off-by: Mohan Narayana <mohan.narayana@mailchimp.com>

Resolves #15 
Impact: **minor**
Type: **bugfix**

## Issue
Product min price gets set to zero if it has a variant with all hidden options.

## Solution
Do not include zeros in the _variantPrices_ array that gets sent to the _getPriceRange()_ 

## Breaking changes
None


## Testing
1. Create a product hierarchy as shown in the image below
![image](https://user-images.githubusercontent.com/75854210/107274500-1a6b5a80-6a16-11eb-93be-cbfc92a9a2ea.png)
2. Run the below query
`query{ products(shopIds:"<shopId>"){ nodes{ _id description title pricing{ price minPrice maxPrice displayPrice compareAtPrice{ amount } } } totalCount } }`
3. The min price (and price range) should not have zero.
